### PR TITLE
fix: correct typo uttirances → utterances across codebase

### DIFF
--- a/src/pulsar_mcp/mcp_engine.py
+++ b/src/pulsar_mcp/mcp_engine.py
@@ -212,7 +212,7 @@ class MCPEngine:
             text = (
                 f"{tool_desc.title}\n"
                 f"{tool_desc.summary}\n"
-                f"Example Utterances: {', '.join(tool_desc.uttirances)}"
+                f"Example Utterances: {', '.join(tool_desc.utterances)}"
             )
             texts.append(text)
         

--- a/src/pulsar_mcp/services/index.py
+++ b/src/pulsar_mcp/services/index.py
@@ -66,7 +66,7 @@ class IndexService:
                         "server_name": server_name,
                         "title": enhanced_tool.title,
                         "summary": enhanced_tool.summary,
-                        "utterances": enhanced_tool.uttirances,
+                        "utterances": enhanced_tool.utterances,
                         "tool_name": tool_name,
                         "tool_description": tool_description,
                         "tool_schema": tool_schema

--- a/src/pulsar_mcp/types.py
+++ b/src/pulsar_mcp/types.py
@@ -24,6 +24,6 @@ class McpServerDescription(BaseModel):
 class McpServerToolDescription(BaseModel):
     title: str = Field(description="A short, descriptive technical title for the tool")
     summary: str = Field(description="A brief summary of the tool's purpose and functionality")
-    uttirances: List[str] = Field(description="Example utterances or commands that can be used to invoke the tool")
+    utterances: List[str] = Field(description="Example utterances or commands that can be used to invoke the tool")
 
     

--- a/tests/test_descriptor.py
+++ b/tests/test_descriptor.py
@@ -1,0 +1,337 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from src.pulsar_mcp.services.descriptor import DescriptorService
+from src.pulsar_mcp.types import McpServerDescription, McpServerToolDescription
+
+
+@pytest.fixture
+def descriptor_service():
+    return DescriptorService(
+        openai_api_key="test-api-key",
+        openai_model_name="gpt-4o-mini"
+    )
+
+
+class TestDescriptorServiceInit:
+    def test_initialization(self, descriptor_service):
+        assert descriptor_service.api_key == "test-api-key"
+        assert descriptor_service.openai_model_name == "gpt-4o-mini"
+
+
+class TestDescriptorServiceContextManager:
+    @pytest.mark.asyncio
+    async def test_context_manager_entry(self, descriptor_service):
+        async with descriptor_service as service:
+            assert service.client is not None
+            assert hasattr(service.client, 'chat')
+
+
+class TestEnhanceQueryWithLLM:
+    @pytest.mark.asyncio
+    async def test_enhance_query_basic(self, descriptor_service):
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_message = MagicMock()
+        mock_message.content = "Enhanced query for file reading operations"
+        mock_choice.message = mock_message
+        mock_response.choices = [mock_choice]
+
+        async with descriptor_service:
+            with patch.object(
+                descriptor_service.client.chat.completions,
+                'create',
+                new_callable=AsyncMock,
+                return_value=mock_response
+            ):
+                result = await descriptor_service.enhance_query_with_llm("read file")
+
+                assert result == "Enhanced query for file reading operations"
+                assert descriptor_service.client.chat.completions.create.call_count == 1
+
+                call_args = descriptor_service.client.chat.completions.create.call_args
+                assert call_args.kwargs['model'] == "gpt-4o-mini"
+                assert call_args.kwargs['max_tokens'] == 384
+                assert len(call_args.kwargs['messages']) == 1
+                assert 'read file' in call_args.kwargs['messages'][0]['content']
+
+    @pytest.mark.asyncio
+    async def test_enhance_query_strips_whitespace(self, descriptor_service):
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_message = MagicMock()
+        mock_message.content = "  Enhanced query with whitespace  \n"
+        mock_choice.message = mock_message
+        mock_response.choices = [mock_choice]
+
+        async with descriptor_service:
+            with patch.object(
+                descriptor_service.client.chat.completions,
+                'create',
+                new_callable=AsyncMock,
+                return_value=mock_response
+            ):
+                result = await descriptor_service.enhance_query_with_llm("test query")
+
+                assert result == "Enhanced query with whitespace"
+                assert not result.startswith(" ")
+                assert not result.endswith(" ")
+
+    @pytest.mark.asyncio
+    async def test_enhance_query_retry_on_connection_error(self, descriptor_service):
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_message = MagicMock()
+        mock_message.content = "Success after retry"
+        mock_choice.message = mock_message
+        mock_response.choices = [mock_choice]
+
+        async with descriptor_service:
+            with patch.object(
+                descriptor_service.client.chat.completions,
+                'create',
+                new_callable=AsyncMock,
+                side_effect=[ConnectionError("Network issue"), mock_response]
+            ):
+                result = await descriptor_service.enhance_query_with_llm("query")
+
+                assert result == "Success after retry"
+                assert descriptor_service.client.chat.completions.create.call_count == 2
+
+
+class TestDescribeMcpServerTool:
+    @pytest.mark.asyncio
+    async def test_describe_tool_basic(self, descriptor_service):
+        mock_tool_desc = McpServerToolDescription(
+            title="File Reader Tool",
+            summary="Reads content from files on the filesystem",
+            utterances=["read file", "get file content", "show file"]
+        )
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_message = MagicMock()
+        mock_message.parsed = mock_tool_desc
+        mock_choice.message = mock_message
+        mock_response.choices = [mock_choice]
+
+        async with descriptor_service:
+            with patch.object(
+                descriptor_service.client.beta.chat.completions,
+                'parse',
+                new_callable=AsyncMock,
+                return_value=mock_response
+            ):
+                tool_schema = {
+                    "type": "object",
+                    "properties": {
+                        "path": {"type": "string"}
+                    }
+                }
+
+                result = await descriptor_service.describe_mcp_server_tool(
+                    tool_name="read_file",
+                    tool_description="Reads a file from disk",
+                    tool_schema=tool_schema,
+                    server_name="filesystem"
+                )
+
+                assert isinstance(result, McpServerToolDescription)
+                assert result.title == "File Reader Tool"
+                assert result.summary == "Reads content from files on the filesystem"
+                assert len(result.utterances) == 3
+                assert "read file" in result.utterances
+
+                call_args = descriptor_service.client.beta.chat.completions.parse.call_args
+                assert call_args.kwargs['model'] == "gpt-4o-mini"
+                assert call_args.kwargs['max_tokens'] == 1024
+                assert call_args.kwargs['response_format'] == McpServerToolDescription
+
+    @pytest.mark.asyncio
+    async def test_describe_tool_with_complex_schema(self, descriptor_service):
+        mock_tool_desc = McpServerToolDescription(
+            title="Search Tool",
+            summary="Performs web searches with filters",
+            utterances=["search web", "find online", "google search"]
+        )
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_message = MagicMock()
+        mock_message.parsed = mock_tool_desc
+        mock_choice.message = mock_message
+        mock_response.choices = [mock_choice]
+
+        async with descriptor_service:
+            with patch.object(
+                descriptor_service.client.beta.chat.completions,
+                'parse',
+                new_callable=AsyncMock,
+                return_value=mock_response
+            ):
+                tool_schema = {
+                    "type": "object",
+                    "properties": {
+                        "query": {"type": "string"},
+                        "max_results": {"type": "integer"},
+                        "filters": {
+                            "type": "object",
+                            "properties": {
+                                "date_range": {"type": "string"}
+                            }
+                        }
+                    },
+                    "required": ["query"]
+                }
+
+                result = await descriptor_service.describe_mcp_server_tool(
+                    tool_name="web_search",
+                    tool_description="Searches the web",
+                    tool_schema=tool_schema,
+                    server_name="search_api"
+                )
+
+                assert result.title == "Search Tool"
+                call_args = descriptor_service.client.beta.chat.completions.parse.call_args
+                assert "web_search" in str(call_args.kwargs['messages'])
+                assert "search_api" in str(call_args.kwargs['messages'])
+
+
+class TestDescribeMcpServer:
+    @pytest.mark.asyncio
+    async def test_describe_server_basic(self, descriptor_service):
+        enhanced_tools = [
+            McpServerToolDescription(
+                title="Read File",
+                summary="Reads files",
+                utterances=["read", "get file"]
+            ),
+            McpServerToolDescription(
+                title="Write File",
+                summary="Writes files",
+                utterances=["write", "save file"]
+            )
+        ]
+
+        mock_server_desc = McpServerDescription(
+            title="Filesystem MCP Server",
+            summary="Provides file system operations",
+            capabilities=["Read files", "Write files", "List directories"],
+            limitations=["No network access", "Limited to local filesystem"]
+        )
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_message = MagicMock()
+        mock_message.parsed = mock_server_desc
+        mock_choice.message = mock_message
+        mock_response.choices = [mock_choice]
+
+        async with descriptor_service:
+            with patch.object(
+                descriptor_service.client.chat.completions,
+                'parse',
+                new_callable=AsyncMock,
+                return_value=mock_response
+            ):
+                result = await descriptor_service.describe_mcp_server(
+                    server_name="filesystem",
+                    enhanced_tools=enhanced_tools
+                )
+
+                assert isinstance(result, McpServerDescription)
+                assert result.title == "Filesystem MCP Server"
+                assert result.summary == "Provides file system operations"
+                assert len(result.capabilities) == 3
+                assert len(result.limitations) == 2
+                assert "Read files" in result.capabilities
+
+                call_args = descriptor_service.client.chat.completions.parse.call_args
+                assert call_args.kwargs['model'] == "gpt-4o-mini"
+                assert call_args.kwargs['max_tokens'] == 2048
+                assert call_args.kwargs['response_format'] == McpServerDescription
+
+    @pytest.mark.asyncio
+    async def test_describe_server_with_single_tool(self, descriptor_service):
+        enhanced_tools = [
+            McpServerToolDescription(
+                title="Echo Tool",
+                summary="Returns input as output",
+                utterances=["echo", "repeat"]
+            )
+        ]
+
+        mock_server_desc = McpServerDescription(
+            title="Echo Server",
+            summary="Simple echo functionality",
+            capabilities=["Echo text"],
+            limitations=["Only echoes text"]
+        )
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_message = MagicMock()
+        mock_message.parsed = mock_server_desc
+        mock_choice.message = mock_message
+        mock_response.choices = [mock_choice]
+
+        async with descriptor_service:
+            with patch.object(
+                descriptor_service.client.chat.completions,
+                'parse',
+                new_callable=AsyncMock,
+                return_value=mock_response
+            ):
+                result = await descriptor_service.describe_mcp_server(
+                    server_name="echo_server",
+                    enhanced_tools=enhanced_tools
+                )
+
+                assert result.title == "Echo Server"
+                call_args = descriptor_service.client.chat.completions.parse.call_args
+                messages = call_args.kwargs['messages']
+                assert len(messages) == 2
+                assert messages[0]['role'] == 'system'
+                assert messages[1]['role'] == 'user'
+
+    @pytest.mark.asyncio
+    async def test_describe_server_includes_all_tools(self, descriptor_service):
+        enhanced_tools = [
+            McpServerToolDescription(
+                title=f"Tool {i}",
+                summary=f"Does task {i}",
+                utterances=[f"task{i}"]
+            )
+            for i in range(5)
+        ]
+
+        mock_server_desc = McpServerDescription(
+            title="Multi-Tool Server",
+            summary="Server with multiple tools",
+            capabilities=["Multiple operations"],
+            limitations=["Rate limited"]
+        )
+
+        mock_response = MagicMock()
+        mock_choice = MagicMock()
+        mock_message = MagicMock()
+        mock_message.parsed = mock_server_desc
+        mock_choice.message = mock_message
+        mock_response.choices = [mock_choice]
+
+        async with descriptor_service:
+            with patch.object(
+                descriptor_service.client.chat.completions,
+                'parse',
+                new_callable=AsyncMock,
+                return_value=mock_response
+            ):
+                result = await descriptor_service.describe_mcp_server(
+                    server_name="multi_tool",
+                    enhanced_tools=enhanced_tools
+                )
+
+                assert result.title == "Multi-Tool Server"
+                call_args = descriptor_service.client.chat.completions.parse.call_args
+                user_message = call_args.kwargs['messages'][1]
+                # Should have system prompt text + 5 tool descriptions
+                assert len(user_message['content']) == 6

--- a/tests/test_embedding.py
+++ b/tests/test_embedding.py
@@ -1,0 +1,212 @@
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+from src.pulsar_mcp.services.embedding import EmbeddingService
+
+
+@pytest.fixture
+def embedding_service():
+    return EmbeddingService(
+        api_key="test-api-key",
+        embedding_model_name="text-embedding-3-small",
+        dimension=1024
+    )
+
+
+class TestEmbeddingServiceInit:
+    def test_initialization(self, embedding_service):
+        assert embedding_service.api_key == "test-api-key"
+        assert embedding_service.embedding_model_name == "text-embedding-3-small"
+        assert embedding_service.dimension == 1024
+
+
+class TestEmbeddingServiceContextManager:
+    @pytest.mark.asyncio
+    async def test_context_manager_entry(self, embedding_service):
+        async with embedding_service as service:
+            assert service.client is not None
+            assert hasattr(service.client, 'embeddings')
+
+
+class TestCreateEmbedding:
+    @pytest.mark.asyncio
+    async def test_create_embedding_single_text(self, embedding_service):
+        mock_response = MagicMock()
+        mock_embedding_item = MagicMock()
+        mock_embedding_item.embedding = [0.1, 0.2, 0.3, 0.4]
+        mock_response.data = [mock_embedding_item]
+
+        async with embedding_service:
+            with patch.object(
+                embedding_service.client.embeddings,
+                'create',
+                new_callable=AsyncMock,
+                return_value=mock_response
+            ):
+                result = await embedding_service.create_embedding(["Hello world"])
+
+                assert len(result) == 1
+                assert result[0] == [0.1, 0.2, 0.3, 0.4]
+
+                embedding_service.client.embeddings.create.assert_called_once_with(
+                    input=["Hello world"],
+                    model="text-embedding-3-small",
+                    dimensions=1024
+                )
+
+    @pytest.mark.asyncio
+    async def test_create_embedding_multiple_texts(self, embedding_service):
+        mock_response = MagicMock()
+        mock_embedding_1 = MagicMock()
+        mock_embedding_1.embedding = [0.1, 0.2, 0.3]
+        mock_embedding_2 = MagicMock()
+        mock_embedding_2.embedding = [0.4, 0.5, 0.6]
+        mock_embedding_3 = MagicMock()
+        mock_embedding_3.embedding = [0.7, 0.8, 0.9]
+        mock_response.data = [mock_embedding_1, mock_embedding_2, mock_embedding_3]
+
+        async with embedding_service:
+            with patch.object(
+                embedding_service.client.embeddings,
+                'create',
+                new_callable=AsyncMock,
+                return_value=mock_response
+            ):
+                texts = ["First text", "Second text", "Third text"]
+                result = await embedding_service.create_embedding(texts)
+
+                assert len(result) == 3
+                assert result[0] == [0.1, 0.2, 0.3]
+                assert result[1] == [0.4, 0.5, 0.6]
+                assert result[2] == [0.7, 0.8, 0.9]
+
+                embedding_service.client.embeddings.create.assert_called_once_with(
+                    input=texts,
+                    model="text-embedding-3-small",
+                    dimensions=1024
+                )
+
+    @pytest.mark.asyncio
+    async def test_create_embedding_empty_list(self, embedding_service):
+        mock_response = MagicMock()
+        mock_response.data = []
+
+        async with embedding_service:
+            with patch.object(
+                embedding_service.client.embeddings,
+                'create',
+                new_callable=AsyncMock,
+                return_value=mock_response
+            ):
+                result = await embedding_service.create_embedding([])
+
+                assert len(result) == 0
+                assert result == []
+
+
+class TestInjectBaseIntoCorpus:
+    def test_inject_base_into_corpus_default_alpha(self, embedding_service):
+        base_embedding = [1.0, 2.0, 3.0, 4.0]
+        corpus_embeddings = [
+            [0.5, 0.5, 0.5, 0.5],
+            [1.0, 1.0, 1.0, 1.0]
+        ]
+
+        result = embedding_service.inject_base_into_corpus(
+            base_embedding,
+            corpus_embeddings,
+            alpha=0.1
+        )
+
+        assert len(result) == 2
+
+        # For first corpus: 0.1 * [1.0, 2.0, 3.0, 4.0] + 0.9 * [0.5, 0.5, 0.5, 0.5]
+        expected_1 = [
+            0.1 * 1.0 + 0.9 * 0.5,  # 0.55
+            0.1 * 2.0 + 0.9 * 0.5,  # 0.65
+            0.1 * 3.0 + 0.9 * 0.5,  # 0.75
+            0.1 * 4.0 + 0.9 * 0.5   # 0.85
+        ]
+        assert result[0] == pytest.approx(expected_1)
+
+        # For second corpus: 0.1 * [1.0, 2.0, 3.0, 4.0] + 0.9 * [1.0, 1.0, 1.0, 1.0]
+        expected_2 = [
+            0.1 * 1.0 + 0.9 * 1.0,  # 1.0
+            0.1 * 2.0 + 0.9 * 1.0,  # 1.1
+            0.1 * 3.0 + 0.9 * 1.0,  # 1.2
+            0.1 * 4.0 + 0.9 * 1.0   # 1.3
+        ]
+        assert result[1] == pytest.approx(expected_2)
+
+    def test_inject_base_into_corpus_custom_alpha(self, embedding_service):
+        base_embedding = [2.0, 4.0]
+        corpus_embeddings = [[1.0, 2.0]]
+
+        result = embedding_service.inject_base_into_corpus(
+            base_embedding,
+            corpus_embeddings,
+            alpha=0.3
+        )
+
+        # 0.3 * [2.0, 4.0] + 0.7 * [1.0, 2.0]
+        expected = [
+            0.3 * 2.0 + 0.7 * 1.0,  # 1.3
+            0.3 * 4.0 + 0.7 * 2.0   # 2.6
+        ]
+        assert result[0] == pytest.approx(expected)
+
+    def test_inject_base_into_corpus_alpha_zero(self, embedding_service):
+        base_embedding = [5.0, 10.0]
+        corpus_embeddings = [[1.0, 2.0]]
+
+        result = embedding_service.inject_base_into_corpus(
+            base_embedding,
+            corpus_embeddings,
+            alpha=0.0
+        )
+
+        # 0.0 * base + 1.0 * corpus = corpus unchanged
+        assert result[0] == [1.0, 2.0]
+
+    def test_inject_base_into_corpus_alpha_one(self, embedding_service):
+        base_embedding = [5.0, 10.0]
+        corpus_embeddings = [[1.0, 2.0]]
+
+        result = embedding_service.inject_base_into_corpus(
+            base_embedding,
+            corpus_embeddings,
+            alpha=1.0
+        )
+
+        # 1.0 * base + 0.0 * corpus = base only
+        assert result[0] == [5.0, 10.0]
+
+    def test_inject_base_into_corpus_empty_corpus(self, embedding_service):
+        base_embedding = [1.0, 2.0, 3.0]
+        corpus_embeddings = []
+
+        result = embedding_service.inject_base_into_corpus(
+            base_embedding,
+            corpus_embeddings,
+            alpha=0.1
+        )
+
+        assert result == []
+
+    def test_inject_base_into_corpus_multiple_vectors(self, embedding_service):
+        base_embedding = [1.0, 1.0, 1.0]
+        corpus_embeddings = [
+            [0.0, 0.0, 0.0],
+            [1.0, 1.0, 1.0],
+            [2.0, 2.0, 2.0]
+        ]
+
+        result = embedding_service.inject_base_into_corpus(
+            base_embedding,
+            corpus_embeddings,
+            alpha=0.5
+        )
+
+        assert len(result) == 3
+        assert result[0] == pytest.approx([0.5, 0.5, 0.5])
+        assert result[1] == pytest.approx([1.0, 1.0, 1.0])
+        assert result[2] == pytest.approx([1.5, 1.5, 1.5])

--- a/tests/test_index.py
+++ b/tests/test_index.py
@@ -1,0 +1,469 @@
+import pytest
+import tempfile
+import shutil
+from unittest.mock import AsyncMock, MagicMock, patch
+from qdrant_client import models
+from src.pulsar_mcp.services.index import IndexService
+from src.pulsar_mcp.types import McpServerDescription, McpServerToolDescription
+
+
+@pytest.fixture
+def temp_storage():
+    path = tempfile.mkdtemp()
+    yield path
+    shutil.rmtree(path, ignore_errors=True)
+
+
+@pytest.fixture
+def index_service(temp_storage):
+    return IndexService(
+        index_name="test_index",
+        dimensions=1024,
+        qdrant_storage_path=temp_storage
+    )
+
+
+class TestIndexServiceInit:
+    def test_initialization(self, index_service):
+        assert index_service.index_name == "test_index"
+        assert index_service.dimensions == 1024
+
+
+class TestIndexServiceContextManager:
+    @pytest.mark.asyncio
+    async def test_context_manager_creates_collection_if_not_exists(self, index_service):
+        async with index_service:
+            assert index_service.client is not None
+            # Collection should be created during __aenter__
+            exists = await index_service.client.collection_exists("test_index")
+            assert exists
+
+    @pytest.mark.asyncio
+    async def test_context_manager_reuses_existing_collection(self, index_service):
+        async with index_service:
+            pass
+
+        # Reopen and collection should still exist
+        async with index_service:
+            exists = await index_service.client.collection_exists("test_index")
+            assert exists
+
+
+class TestAddServer:
+    @pytest.mark.asyncio
+    async def test_add_server_basic(self, index_service):
+        async with index_service:
+            server_desc = McpServerDescription(
+                title="Test Server",
+                summary="A test MCP server",
+                capabilities=["cap1", "cap2"],
+                limitations=["limit1"]
+            )
+            embedding = [0.1] * 1024
+
+            await index_service.add_server(
+                server_name="test_server",
+                mcp_server_description=server_desc,
+                embedding=embedding,
+                nb_tools=5
+            )
+
+            # Verify server was added
+            result = await index_service.get_server("test_server")
+            assert result is not None
+            assert result["type"] == "server"
+            assert result["server_name"] == "test_server"
+            assert result["title"] == "Test Server"
+            assert result["nb_tools"] == 5
+
+    @pytest.mark.asyncio
+    async def test_add_server_updates_existing(self, index_service):
+        async with index_service:
+            server_desc1 = McpServerDescription(
+                title="Server V1",
+                summary="First version",
+                capabilities=["cap1"],
+                limitations=[]
+            )
+
+            server_desc2 = McpServerDescription(
+                title="Server V2",
+                summary="Second version",
+                capabilities=["cap1", "cap2"],
+                limitations=["limit1"]
+            )
+
+            embedding = [0.1] * 1024
+
+            # Add first version
+            await index_service.add_server("my_server", server_desc1, embedding, 3)
+
+            # Update with second version
+            await index_service.add_server("my_server", server_desc2, embedding, 5)
+
+            # Should have the updated version
+            result = await index_service.get_server("my_server")
+            assert result["title"] == "Server V2"
+            assert result["nb_tools"] == 5
+            assert len(result["capabilities"]) == 2
+
+
+class TestAddTool:
+    @pytest.mark.asyncio
+    async def test_add_tool_basic(self, index_service):
+        async with index_service:
+            tool_desc = McpServerToolDescription(
+                title="Test Tool",
+                summary="A test tool",
+                utterances=["use tool", "run tool"]
+            )
+            embedding = [0.2] * 1024
+            schema = {"type": "object", "properties": {}}
+
+            await index_service.add_tool(
+                server_name="test_server",
+                tool_name="test_tool",
+                tool_description="Does testing",
+                tool_schema=schema,
+                embedding=embedding,
+                enhanced_tool=tool_desc
+            )
+
+            # Verify tool was added
+            result = await index_service.get_tool("test_server", "test_tool")
+            assert result is not None
+            assert result["type"] == "tool"
+            assert result["server_name"] == "test_server"
+            assert result["tool_name"] == "test_tool"
+            assert result["title"] == "Test Tool"
+            assert len(result["utterances"]) == 2
+
+
+class TestGetServer:
+    @pytest.mark.asyncio
+    async def test_get_server_exists(self, index_service):
+        async with index_service:
+            server_desc = McpServerDescription(
+                title="My Server",
+                summary="Summary",
+                capabilities=["cap1"],
+                limitations=[]
+            )
+            await index_service.add_server("my_server", server_desc, [0.1] * 1024, 2)
+
+            result = await index_service.get_server("my_server")
+            assert result is not None
+            assert result["server_name"] == "my_server"
+
+    @pytest.mark.asyncio
+    async def test_get_server_not_exists(self, index_service):
+        async with index_service:
+            result = await index_service.get_server("nonexistent_server")
+            assert result is None
+
+
+class TestGetTool:
+    @pytest.mark.asyncio
+    async def test_get_tool_exists(self, index_service):
+        async with index_service:
+            tool_desc = McpServerToolDescription(
+                title="Tool",
+                summary="Summary",
+                utterances=["use"]
+            )
+            await index_service.add_tool(
+                "server1", "tool1", "desc", {}, [0.1] * 1024, tool_desc
+            )
+
+            result = await index_service.get_tool("server1", "tool1")
+            assert result is not None
+            assert result["tool_name"] == "tool1"
+
+    @pytest.mark.asyncio
+    async def test_get_tool_not_exists(self, index_service):
+        async with index_service:
+            result = await index_service.get_tool("server1", "nonexistent_tool")
+            assert result is None
+
+
+class TestDeleteServer:
+    @pytest.mark.asyncio
+    async def test_delete_server_without_tools(self, index_service):
+        async with index_service:
+            server_desc = McpServerDescription(
+                title="Server",
+                summary="Summary",
+                capabilities=[],
+                limitations=[]
+            )
+            await index_service.add_server("server1", server_desc, [0.1] * 1024, 0)
+
+            result = await index_service.delete_server("server1")
+            assert result is not None
+            assert result["server_name"] == "server1"
+
+            # Verify deleted
+            check = await index_service.get_server("server1")
+            assert check is None
+
+    @pytest.mark.asyncio
+    async def test_delete_server_with_tools(self, index_service):
+        async with index_service:
+            # Add server
+            server_desc = McpServerDescription(
+                title="Server",
+                summary="Summary",
+                capabilities=[],
+                limitations=[]
+            )
+            await index_service.add_server("server1", server_desc, [0.1] * 1024, 2)
+
+            # Add tools
+            tool_desc = McpServerToolDescription(
+                title="Tool",
+                summary="Summary",
+                utterances=["use"]
+            )
+            await index_service.add_tool("server1", "tool1", "desc", {}, [0.2] * 1024, tool_desc)
+            await index_service.add_tool("server1", "tool2", "desc", {}, [0.3] * 1024, tool_desc)
+
+            # Delete server (should delete tools too)
+            result = await index_service.delete_server("server1")
+            assert result["server_name"] == "server1"
+
+            # Verify server deleted
+            check_server = await index_service.get_server("server1")
+            assert check_server is None
+
+            # Verify tools deleted
+            check_tool1 = await index_service.get_tool("server1", "tool1")
+            check_tool2 = await index_service.get_tool("server1", "tool2")
+            assert check_tool1 is None
+            assert check_tool2 is None
+
+
+class TestSearch:
+    @pytest.mark.asyncio
+    async def test_search_basic(self, index_service):
+        async with index_service:
+            # Add some tools
+            tool_desc = McpServerToolDescription(
+                title="Tool",
+                summary="Summary",
+                utterances=["use"]
+            )
+            await index_service.add_tool("server1", "tool1", "desc", {}, [0.9] * 1024, tool_desc)
+            await index_service.add_tool("server1", "tool2", "desc", {}, [0.5] * 1024, tool_desc)
+
+            # Search with similar embedding
+            results = await index_service.search([0.9] * 1024, top_k=5)
+
+            assert len(results) >= 1
+            assert all("score" in r for r in results)
+            assert all("payload" in r for r in results)
+
+    @pytest.mark.asyncio
+    async def test_search_with_server_filter(self, index_service):
+        async with index_service:
+            tool_desc = McpServerToolDescription(
+                title="Tool",
+                summary="Summary",
+                utterances=["use"]
+            )
+            await index_service.add_tool("server1", "tool1", "desc", {}, [0.9] * 1024, tool_desc)
+            await index_service.add_tool("server2", "tool2", "desc", {}, [0.9] * 1024, tool_desc)
+
+            # Search only server1
+            results = await index_service.search(
+                [0.9] * 1024,
+                top_k=10,
+                server_names=["server1"]
+            )
+
+            assert all(r["payload"]["server_name"] == "server1" for r in results)
+
+    @pytest.mark.asyncio
+    async def test_search_with_scope_filter(self, index_service):
+        async with index_service:
+            # Add server and tool
+            server_desc = McpServerDescription(
+                title="Server",
+                summary="Summary",
+                capabilities=[],
+                limitations=[]
+            )
+            tool_desc = McpServerToolDescription(
+                title="Tool",
+                summary="Summary",
+                utterances=["use"]
+            )
+
+            await index_service.add_server("server1", server_desc, [0.9] * 1024, 1)
+            await index_service.add_tool("server1", "tool1", "desc", {}, [0.9] * 1024, tool_desc)
+
+            # Search only tools
+            results = await index_service.search([0.9] * 1024, top_k=10, scope=["tool"])
+
+            assert all(r["payload"]["type"] == "tool" for r in results)
+
+
+class TestListServers:
+    @pytest.mark.asyncio
+    async def test_list_servers_empty(self, index_service):
+        async with index_service:
+            results, next_id = await index_service.list_servers()
+            assert results == []
+            assert next_id is None
+
+    @pytest.mark.asyncio
+    async def test_list_servers_basic(self, index_service):
+        async with index_service:
+            server_desc = McpServerDescription(
+                title="Server",
+                summary="Summary",
+                capabilities=[],
+                limitations=[]
+            )
+
+            await index_service.add_server("server1", server_desc, [0.1] * 1024, 0)
+            await index_service.add_server("server2", server_desc, [0.2] * 1024, 0)
+
+            results, next_id = await index_service.list_servers()
+
+            assert len(results) == 2
+            server_names = [r["server_name"] for r in results]
+            assert "server1" in server_names
+            assert "server2" in server_names
+
+    @pytest.mark.asyncio
+    async def test_list_servers_with_ignore(self, index_service):
+        async with index_service:
+            server_desc = McpServerDescription(
+                title="Server",
+                summary="Summary",
+                capabilities=[],
+                limitations=[]
+            )
+
+            await index_service.add_server("server1", server_desc, [0.1] * 1024, 0)
+            await index_service.add_server("server2", server_desc, [0.2] * 1024, 0)
+            await index_service.add_server("server3", server_desc, [0.3] * 1024, 0)
+
+            results, next_id = await index_service.list_servers(ignore_servers=["server2"])
+
+            assert len(results) == 2
+            server_names = [r["server_name"] for r in results]
+            assert "server1" in server_names
+            assert "server3" in server_names
+            assert "server2" not in server_names
+
+
+class TestListTools:
+    @pytest.mark.asyncio
+    async def test_list_tools_empty(self, index_service):
+        async with index_service:
+            results, next_id = await index_service.list_tools("server1")
+            assert results == []
+
+    @pytest.mark.asyncio
+    async def test_list_tools_basic(self, index_service):
+        async with index_service:
+            tool_desc = McpServerToolDescription(
+                title="Tool",
+                summary="Summary",
+                utterances=["use"]
+            )
+
+            await index_service.add_tool("server1", "tool1", "desc", {}, [0.1] * 1024, tool_desc)
+            await index_service.add_tool("server1", "tool2", "desc", {}, [0.2] * 1024, tool_desc)
+            await index_service.add_tool("server2", "tool3", "desc", {}, [0.3] * 1024, tool_desc)
+
+            results, next_id = await index_service.list_tools("server1")
+
+            assert len(results) == 2
+            tool_names = [r["tool_name"] for r in results]
+            assert "tool1" in tool_names
+            assert "tool2" in tool_names
+            assert "tool3" not in tool_names
+
+
+class TestNbServers:
+    @pytest.mark.asyncio
+    async def test_nb_servers_empty(self, index_service):
+        async with index_service:
+            count = await index_service.nb_servers()
+            assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_nb_servers_basic(self, index_service):
+        async with index_service:
+            server_desc = McpServerDescription(
+                title="Server",
+                summary="Summary",
+                capabilities=[],
+                limitations=[]
+            )
+
+            await index_service.add_server("server1", server_desc, [0.1] * 1024, 0)
+            await index_service.add_server("server2", server_desc, [0.2] * 1024, 0)
+            await index_service.add_server("server3", server_desc, [0.3] * 1024, 0)
+
+            count = await index_service.nb_servers()
+            assert count == 3
+
+    @pytest.mark.asyncio
+    async def test_nb_servers_with_ignore(self, index_service):
+        async with index_service:
+            server_desc = McpServerDescription(
+                title="Server",
+                summary="Summary",
+                capabilities=[],
+                limitations=[]
+            )
+
+            await index_service.add_server("server1", server_desc, [0.1] * 1024, 0)
+            await index_service.add_server("server2", server_desc, [0.2] * 1024, 0)
+            await index_service.add_server("server3", server_desc, [0.3] * 1024, 0)
+
+            count = await index_service.nb_servers(ignore_servers=["server1", "server3"])
+            assert count == 1
+
+
+class TestNbTools:
+    @pytest.mark.asyncio
+    async def test_nb_tools_empty(self, index_service):
+        async with index_service:
+            count = await index_service.nb_tools()
+            assert count == 0
+
+    @pytest.mark.asyncio
+    async def test_nb_tools_basic(self, index_service):
+        async with index_service:
+            tool_desc = McpServerToolDescription(
+                title="Tool",
+                summary="Summary",
+                utterances=["use"]
+            )
+
+            await index_service.add_tool("server1", "tool1", "desc", {}, [0.1] * 1024, tool_desc)
+            await index_service.add_tool("server1", "tool2", "desc", {}, [0.2] * 1024, tool_desc)
+            await index_service.add_tool("server2", "tool3", "desc", {}, [0.3] * 1024, tool_desc)
+
+            count = await index_service.nb_tools()
+            assert count == 3
+
+    @pytest.mark.asyncio
+    async def test_nb_tools_with_ignore(self, index_service):
+        async with index_service:
+            tool_desc = McpServerToolDescription(
+                title="Tool",
+                summary="Summary",
+                utterances=["use"]
+            )
+
+            await index_service.add_tool("server1", "tool1", "desc", {}, [0.1] * 1024, tool_desc)
+            await index_service.add_tool("server2", "tool2", "desc", {}, [0.2] * 1024, tool_desc)
+            await index_service.add_tool("server3", "tool3", "desc", {}, [0.3] * 1024, tool_desc)
+
+            count = await index_service.nb_tools(ignore_servers=["server1"])
+            assert count == 2

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -101,7 +101,7 @@ class TestMcpServerToolDescription:
         desc = McpServerToolDescription(
             title="Read File Tool",
             summary="Reads content from a file",
-            uttirances=["read the file", "get file content", "show me the file"]
+            utterances=["read the file", "get file content", "show me the file"]
         )
         assert desc.title == "Read File Tool"
-        assert len(desc.uttirances) == 3
+        assert len(desc.utterances) == 3


### PR DESCRIPTION
Fixed spelling error in field name across all affected files:
- types.py (model definition)
- mcp_engine.py (usage in f-string)
- services/index.py (payload dictionary)
- tests/test_types.py (test assertions)